### PR TITLE
fix: refactoring

### DIFF
--- a/code247/html/joystick.html
+++ b/code247/html/joystick.html
@@ -43,8 +43,10 @@
     manager.on('start', (evt, data) => {
       startPosition = { x: data.position.x, y: data.position.y };
       vscode.postMessage({
-        command:"startRadialMenu",
+        command:"joystick",
         data: {
+          mode:"menu",
+          status: "start",
           position: startPosition,
         },
       });
@@ -55,8 +57,10 @@
       const relativeY = data.position.y - startPosition.y;
       movePosition = { x: relativeX, y: relativeY };
       vscode.postMessage({
-        command:"updateRadialMenu",
+        command:"joystick",
         data: {
+          mode:"menu",
+          status:"update",
           position: movePosition,
         },
       });
@@ -65,8 +69,10 @@
 
     manager.on('end', (evt, data) => {
       vscode.postMessage({
-        command: 'endRadialMenu',
-        date: {
+        command:"joystick",
+        data: {
+          mode:"menu",
+          status:"end",
           position: movePosition,
         },
       });

--- a/code247/package.json
+++ b/code247/package.json
@@ -21,9 +21,28 @@
       {
         "command": "code247.start",
         "title": "start",
-        "category": "Phone Editor"
+        "category": "code247"
       }
-    ]
+    ],
+    "configuration": {
+      "title": "code247",
+      "properties": {
+        "code247.mode": {
+          "type": [
+            "string"
+          ],
+          "default": "menu",
+          "description": "code247 mode"
+        },
+        "code247.joystickDoubleTapInterval": {
+          "type": [
+            "number"
+          ],
+          "default": 1000,
+          "description": "code247 Joystick Double Tap Interval"
+        }
+      }
+    }
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",

--- a/code247/src/extension.ts
+++ b/code247/src/extension.ts
@@ -117,37 +117,10 @@ class Code247Panel {
      */
     this._panel.webview.onDidReceiveMessage(
       (message) => {
-        vscode.window.showInformationMessage("Hello", message);
         const editor = vscode.window.activeTextEditor;
         switch (message.command) {
-          case "startRadialMenu":
-            vscode.window.showInformationMessage("joystickStart", message.data);
-            if (editor) {
-              this.showRadialMenu(
-                editor,
-                message.data.position.x,
-                message.data.position.y,
-              );
-            }
-            break;
-          case "updateRadialMenu":
-            vscode.window.showInformationMessage(
-              "joystickUpdate",
-              message.data,
-            );
-            if (editor) {
-              this.updateRadialMenu(
-                editor,
-                message.data.position.x,
-                message.data.position.y,
-              );
-            }
-            break;
-          case "endRadialMenu":
-            vscode.window.showInformationMessage("joystickEnd", message.data);
-            if (editor) {
-              this.hideRadialMenu(editor);
-            }
+          case "joystick":
+            this.joystick(message, editor);
             break;
         }
       },
@@ -178,6 +151,45 @@ class Code247Panel {
     const htmlContent = new TextDecoder("utf-8").decode(data);
 
     return htmlContent;
+  }
+
+  private joystick(message: any, editor: vscode.TextEditor | undefined) {
+    switch (message.data.mode) {
+      case "menu":
+        this.joystickMenu(message, editor);
+        break;
+    }
+  }
+
+  private joystickMenu(message: any, editor: vscode.TextEditor | undefined) {
+    switch (message.data.status) {
+      case "start":
+        vscode.window.showInformationMessage("joystickStart", message.data);
+        if (editor) {
+          this.showRadialMenu(
+            editor,
+            message.data.position.x,
+            message.data.position.y,
+          );
+        }
+        break;
+      case "update":
+        vscode.window.showInformationMessage("joystickUpdate", message.data);
+        if (editor) {
+          this.updateRadialMenu(
+            editor,
+            message.data.position.x,
+            message.data.position.y,
+          );
+        }
+        break;
+      case "end":
+        vscode.window.showInformationMessage("joystickEnd", message.data);
+        if (editor) {
+          this.hideRadialMenu(editor);
+        }
+        break;
+    }
   }
 
   private showRadialMenu(editor: vscode.TextEditor, x: number, y: number) {

--- a/code247/src/extension.ts
+++ b/code247/src/extension.ts
@@ -40,7 +40,7 @@ class Code247Panel {
 
   private readonly _panel: vscode.WebviewPanel;
   private _disposables: vscode.Disposable[] = [];
-  private radialMenuDecoration: vscode.TextEditorDecorationType | null = null;
+  private radialMenuDecoration: vscode.TextEditorDecorationType[] = [];
 
   /**
    * 1度も開いたことがない場合は新しく作成し、開いている場合は表示する
@@ -264,31 +264,34 @@ class Code247Panel {
   );
   `;
 
-    this.radialMenuDecoration = vscode.window.createTextEditorDecorationType({
-      before: {
-        contentText: "",
-        textDecoration: `none; ${cssString}`,
-      },
-      isWholeLine: false,
-    });
+    this.radialMenuDecoration.push(
+      vscode.window.createTextEditorDecorationType({
+        before: {
+          contentText: "",
+          textDecoration: `none; ${cssString}`,
+        },
+        isWholeLine: false,
+      }),
+    );
 
     const position = new vscode.Position(0, 0);
-    editor.setDecorations(this.radialMenuDecoration, [
-      { range: new vscode.Range(position, position) },
-    ]);
+    editor.setDecorations(
+      this.radialMenuDecoration[this.radialMenuDecoration.length - 1],
+      [{ range: new vscode.Range(position, position) }],
+    );
   }
 
   private updateRadialMenu(editor: vscode.TextEditor, x: number, y: number) {
-    this.hideRadialMenu(editor);
     this.showRadialMenu(editor, x, y);
+    this.hideRadialMenu(editor);
   }
 
   private hideRadialMenu(editor: vscode.TextEditor) {
-    if (this.radialMenuDecoration === null) {
+    if (this.radialMenuDecoration.length === 0) {
       return;
     }
-    editor.setDecorations(this.radialMenuDecoration, []);
-    this.radialMenuDecoration = null;
+    const decorator = this.radialMenuDecoration.shift();
+    decorator?.dispose();
   }
 
   public dispose() {

--- a/code247/src/extension.ts
+++ b/code247/src/extension.ts
@@ -170,12 +170,9 @@ class Code247Panel {
           const now = new Date();
           const diff =
             now.getTime() - Code247Panel.joystickLastStartedAt.getTime();
-          let joystickDoubleTapInterval: number | undefined = vscode.workspace
+          let joystickDoubleTapInterval = vscode.workspace
             .getConfiguration("code247")
-            .get("joystickDoubleTapInterval");
-          if (typeof joystickDoubleTapInterval !== "number") {
-            joystickDoubleTapInterval = 1000;
-          }
+            .get<number>("joystickDoubleTapInterval", 1000);
           if (diff < joystickDoubleTapInterval) {
             Code247Panel.isDoubleTap = true;
           } else {


### PR DESCRIPTION
- 複数のmodeをconfigからとってきて扱いやすいようにするリファクタリング
- doubleTapの概念を追加
- ちらつき軽減


`code247.joystickDoubleTapInterval` ミリ秒の間にダブルタップするとダブルタップ判定になります
現状はオレンジ色のラジアルメニューを表示するだけです


https://github.com/user-attachments/assets/ad17fc2b-1272-4df3-872d-a6700a63aced


